### PR TITLE
fix: unusable ref key

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -53,16 +53,11 @@ async function start(fields) {
     const contacts = await googleHelper.getAllContacts({
       personFields: FIELDS.join(',')
     })
-    const ioCozyContacts = contacts.map(transpile.toCozy).map(contact => ({
-      ...contact,
-      metadata: {
-        google: {
-          ...contact.metadata['google'],
-          from: accountInfo.emails[0].value
-        }
-      }
-    }))
-    return updateOrCreate(ioCozyContacts, 'io.cozy.contacts', ['resourceName'])
+    const ioCozyContacts = contacts.map(transpile.toCozy).map(contact => {
+      contact.metadata.google.from = accountInfo.emails[0].value
+      return contact
+    })
+    return updateOrCreate(ioCozyContacts, 'io.cozy.contacts', ['vendorId'])
   } catch (err) {
     throw new Error(`a global konnector error: ${err.message}`)
   }

--- a/src/transpiler.js
+++ b/src/transpiler.js
@@ -13,9 +13,9 @@ const transpiler = {
       address: getAddress(source),
       metadata: {
         version: SCHEMA_VERSION,
-        google: { metadata: source.metadata },
-        vendorId: source.resourceName
-      }
+        google: { metadata: source.metadata }
+      },
+      vendorId: source.resourceName
     }
   }
 }


### PR DESCRIPTION
I would like to stop using `updateOrCreate` but it will be for later, for now I fix the behavior that prevented importing changes from a contact.