### PR TITLE
fix: Map notes field to biographies in google contacts

### DIFF
--- a/sample/alanturing.json
+++ b/sample/alanturing.json
@@ -119,9 +119,9 @@
       "contactGroupMembership": { "contactGroupId": "myContacts" }
     }
   ],
-  "userDefined": [
+  "biographies": [
     {
-      "key": "note",
+      "contentType": "TEXT_PLAIN",
       "value": "Doloribus animi corporis et qui error cumque culpa autem velit."
     }
   ]

--- a/sample/google-contacts.json
+++ b/sample/google-contacts.json
@@ -572,9 +572,9 @@
         "contactGroupMembership": { "contactGroupId": "myContacts" }
       }
     ],
-    "userDefined": [
+    "biographies": [
       {
-        "key": "note",
+        "contentType": "TEXT_PLAIN",
         "value": "Beatae atque omnis nostrum eum. Quia sint ea a consequatur tempore et et animi. Ad quae perferendis sit qui aut fugiat deserunt."
       },
       {
@@ -712,9 +712,9 @@
         "contactGroupMembership": { "contactGroupId": "myContacts" }
       }
     ],
-    "userDefined": [
+    "biographies": [
       {
-        "key": "note",
+        "contentType": "TEXT_PLAIN",
         "value": "Beatae atque omnis nostrum eum. Quia sint ea a consequatur tempore et et animi. Ad quae perferendis sit qui aut fugiat deserunt."
       }
     ]

--- a/src/transpiler.js
+++ b/src/transpiler.js
@@ -28,7 +28,7 @@ const transpiler = {
       addresses: getAddresses(source),
       birthdays: getBirthdays(source),
       organizations: getOrganizations(source),
-      userDefined: getUserDefined(source)
+      biographies: getBiographies(source)
     }
   }
 }
@@ -101,11 +101,8 @@ function getCompany({ organizations = undefined }) {
   return organizations && organizations[0].name
 }
 
-function getNote({ userDefined = undefined }) {
-  return (
-    (userDefined && userDefined.find(ud => ud.key === 'note').value) ||
-    undefined
-  )
+function getNote({ biographies = undefined }) {
+  return (biographies && biographies[0] && biographies[0].value) || undefined
 }
 
 // cozy -> google
@@ -185,11 +182,11 @@ function getOrganizations({ company = undefined }) {
   )
 }
 
-function getUserDefined({ note = undefined }) {
+function getBiographies({ note = undefined }) {
   return (
     note && [
       {
-        key: 'note',
+        contentType: 'TEXT_PLAIN',
         value: note
       }
     ]

--- a/src/transpiler.spec.js
+++ b/src/transpiler.spec.js
@@ -158,9 +158,9 @@ describe('Transpile from io.cozy.contacts to google-contacts', () => {
           name: 'Cozy cloud'
         }
       ],
-      userDefined: [
+      biographies: [
         {
-          key: 'note',
+          contentType: 'TEXT_PLAIN',
           value:
             'Atque cupiditate saepe omnis quos ut molestiae labore voluptates omnis.'
         }


### PR DESCRIPTION
Google contacts uses the biographies field to store notes about the person. Map this field to cozy `note` field instead of a user defined field (custom).