### PR TITLE
fix: Transpile birthday (google to cozy)

### DIFF
--- a/src/__snapshots__/transpiler.spec.js.snap
+++ b/src/__snapshots__/transpiler.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Transpile from google-contacts to io.cozy-contacts Simple test 1`] = `
+exports[`Transpile from google-contacts to io.cozy-contacts should transpile alan turing 1`] = `
 Object {
   "address": Array [
     Object {
@@ -13,7 +13,7 @@ Object {
       "type": "work",
     },
   ],
-  "birthday": "1912-06-22",
+  "birthday": "1912-06-23",
   "company": "National Physical Laboratory",
   "email": Array [
     Object {
@@ -68,7 +68,7 @@ Object {
 }
 `;
 
-exports[`Transpile from google-contacts to io.cozy-contacts complete tests with \`sample/*.json 1`] = `
+exports[`Transpile from google-contacts to io.cozy-contacts should transpile all contacts from \`sample/*.json 1`] = `
 Array [
   Object {
     "doc": Object {
@@ -138,7 +138,7 @@ Array [
           "type": undefined,
         },
       ],
-      "birthday": "1987-10-04",
+      "birthday": "1987-10-05",
       "company": undefined,
       "email": Array [
         Object {
@@ -205,7 +205,7 @@ Array [
           "type": "work",
         },
       ],
-      "birthday": "1912-06-22",
+      "birthday": "1912-06-23",
       "company": "National Physical Laboratory",
       "email": Array [
         Object {
@@ -317,7 +317,7 @@ Array [
           "type": undefined,
         },
       ],
-      "birthday": "0297-12-31",
+      "birthday": "0298-01-01",
       "company": "Night's Watch",
       "email": Array [
         Object {

--- a/src/transpiler.js
+++ b/src/transpiler.js
@@ -51,18 +51,14 @@ function getAddress({ addresses = [] }) {
 }
 
 function getBirthday({ birthdays = [] }) {
-  return birthdays
-    .filter(
-      birthday => birthday && birthday.metadata && birthday.metadata.primary
-    )
-    .map(
-      birthday =>
-        birthday &&
-        birthday.date &&
-        /\d\d\d\d-\d\d-\d\d/.exec(
-          new Date(Object.values(birthday.date).join('-')).toISOString()
-        )[0]
-    )[0]
+  const DATE_AND_TIME_SEPARATOR = 'T'
+  const birthday =
+    birthdays.find(b => b.metadata && b.metadata.primary) || birthdays[0]
+  if (birthday && birthday.date) {
+    const { year, month, day } = birthday.date
+    const isoDate = new Date(Date.UTC(year, month - 1, day)).toISOString()
+    return isoDate.split(DATE_AND_TIME_SEPARATOR)[0]
+  }
 }
 
 function getEmail({ emailAddresses = [] }) {

--- a/src/transpiler.spec.js
+++ b/src/transpiler.spec.js
@@ -1,14 +1,14 @@
 const transpile = require('./transpiler')
 
 describe('Transpile from google-contacts to io.cozy-contacts', () => {
-  test('Simple test', () => {
+  it('should transpile alan turing', () => {
     const source = require('../sample/alanturing.json')
 
     const transpiled = transpile.toCozy(source)
     expect(transpiled).toMatchSnapshot()
   })
 
-  test('complete tests with `sample/*.json', () => {
+  it('should transpile all contacts from `sample/*.json', () => {
     const source = require('../sample/google-contacts.json')
 
     const transpiled = source.map(row => ({


### PR DESCRIPTION
We had an issue with timezones during birthday transpilation. This PR rewrites `getBirthday` and fix this (we just split the ISO date at `T` and take the first part)