### PR TITLE
Fix: Don't import vendor ID

### DIFF
--- a/src/__snapshots__/synchronizeContacts.spec.js.snap
+++ b/src/__snapshots__/synchronizeContacts.spec.js.snap
@@ -43,7 +43,6 @@ Array [
     },
     "note": null,
     "phone": Array [],
-    "vendorId": "people/944070",
   },
 ]
 `;
@@ -105,7 +104,6 @@ Array [
     },
     "note": null,
     "phone": Array [],
-    "vendorId": "people/987654",
   },
 ]
 `;
@@ -204,7 +202,6 @@ Array [
     },
     "note": null,
     "phone": Array [],
-    "vendorId": "people/751021",
   },
 ]
 `;
@@ -252,7 +249,6 @@ Array [
     },
     "note": null,
     "phone": Array [],
-    "vendorId": null,
   },
 ]
 `;
@@ -319,7 +315,6 @@ Array [
     },
     "note": null,
     "phone": Array [],
-    "vendorId": null,
   },
 ]
 `;
@@ -390,7 +385,6 @@ Array [
     },
     "note": null,
     "phone": Array [],
-    "vendorId": "people/364391",
   },
 ]
 `;

--- a/src/__snapshots__/transpiler.spec.js.snap
+++ b/src/__snapshots__/transpiler.spec.js.snap
@@ -64,7 +64,6 @@ Object {
       "type": "work",
     },
   ],
-  "vendorId": "people/c8396630372093629671",
 }
 `;
 
@@ -122,7 +121,6 @@ Array [
           "type": undefined,
         },
       ],
-      "vendorId": "people/c2584501361615515329",
     },
   },
   Object {
@@ -189,7 +187,6 @@ Array [
           "type": undefined,
         },
       ],
-      "vendorId": "people/c3745049716692310153",
     },
   },
   Object {
@@ -256,7 +253,6 @@ Array [
           "type": "work",
         },
       ],
-      "vendorId": "people/c8396630372093629671",
     },
   },
   Object {
@@ -301,7 +297,6 @@ Array [
           "type": "mobile",
         },
       ],
-      "vendorId": "people/c2701561889201335426",
     },
   },
   Object {
@@ -349,7 +344,6 @@ Array [
       },
       "note": undefined,
       "phone": Array [],
-      "vendorId": "people/c6437718916715038152",
     },
   },
   Object {
@@ -393,7 +387,6 @@ Array [
       },
       "note": "Beatae atque omnis nostrum eum. Quia sint ea a consequatur tempore et et animi. Ad quae perferendis sit qui aut fugiat deserunt.",
       "phone": Array [],
-      "vendorId": "people/c2315637590020431536",
     },
   },
   Object {
@@ -431,7 +424,6 @@ Array [
       },
       "note": undefined,
       "phone": Array [],
-      "vendorId": "people/c1639879180286560138",
     },
   },
   Object {
@@ -476,7 +468,6 @@ Array [
           "type": undefined,
         },
       ],
-      "vendorId": "people/c7575342359908918582",
     },
   },
 ]

--- a/src/transpiler.js
+++ b/src/transpiler.js
@@ -16,8 +16,7 @@ const transpiler = {
         google: { metadata: source.metadata }
       },
       company: getCompany(source),
-      note: getNote(source),
-      vendorId: source.resourceName
+      note: getNote(source)
     }
   },
   toGoogle: source => {


### PR DESCRIPTION
We were importing this field, but I don't think we  want to keep it? It isn't referenced in any of our working documents.