### PR TITLE
Sync delete cozy to google

### DIFF
--- a/src/__snapshots__/synchronizeContacts.spec.js.snap
+++ b/src/__snapshots__/synchronizeContacts.spec.js.snap
@@ -91,6 +91,60 @@ Array [
 ]
 `;
 
+exports[`synchronizeContacts function should synchronize contacts: destroyFabiolaGrozdanaInCozy 1`] = `
+Array [
+  Object {
+    "_rev": "678aad8-fa2b-482c-b9b9-8768bcfe3",
+    "_type": "io.cozy.contacts",
+    "address": Array [],
+    "birthday": null,
+    "company": null,
+    "cozyMetadata": Object {
+      "createdAt": "2017-03-22T07:33:00.123Z",
+      "createdByApp": "Contacts",
+      "createdByAppVersion": "2.0.0",
+      "doctypeVersion": 2,
+      "importedAt": "2016-11-25T19:33:00.123Z",
+      "importedFrom": "Contacts",
+      "sourceAccount": "45c49c15-4b00-48e8-8bfd-29f8177b89ff",
+      "sync": Object {
+        "45c49c15-4b00-48e8-8bfd-29f8177b89ff": Object {
+          "id": "people/924609",
+          "remoteRev": "ea79ad60-8c9f-4143-830f-07dfb260630b",
+        },
+      },
+      "updatedAt": "2018-11-12T18:18:00.222Z",
+      "updatedByApps": Array [
+        "Contacts",
+        "konnector-google",
+      ],
+    },
+    "email": Array [],
+    "id": "fabiola-grozdana-deleted-on-cozy",
+    "metadata": Object {
+      "google": Object {
+        "metadata": null,
+      },
+      "version": 1,
+    },
+    "name": Object {
+      "familyName": "Grozdana",
+      "givenName": "Fabiola",
+    },
+    "note": null,
+    "phone": Array [],
+    "trashed": true,
+    "vendorId": null,
+  },
+]
+`;
+
+exports[`synchronizeContacts function should synchronize contacts: fabiolaGrozdanaInGoogle 1`] = `
+Array [
+  "people/924609",
+]
+`;
+
 exports[`synchronizeContacts function should synchronize contacts: johnDoeInCozy 1`] = `
 Array [
   Object {

--- a/src/google.js
+++ b/src/google.js
@@ -114,5 +114,19 @@ module.exports = (() => ({
     } catch (err) {
       throw new Error(`Unable to update contact ${err.message}`)
     }
+  },
+  deleteContact: function(resourceName) {
+    const peopleAPI = google.people({
+      version: 'v1',
+      auth: this.oAuth2Client
+    })
+
+    try {
+      return peopleAPI.people.deleteContact({
+        resourceName
+      })
+    } catch (err) {
+      throw new Error(`Unable to delete contact ${err.message}`)
+    }
   }
 }))()

--- a/src/google.js
+++ b/src/google.js
@@ -87,14 +87,10 @@ module.exports = (() => ({
       auth: this.oAuth2Client
     })
 
-    try {
-      return peopleAPI.people.createContact({
-        parent: 'people/me',
-        requestBody: person
-      })
-    } catch (err) {
-      throw new Error(`Unable to create contact ${err.message}`)
-    }
+    return peopleAPI.people.createContact({
+      parent: 'people/me',
+      requestBody: person
+    })
   },
   updateContact: function(person, resourceName, etag) {
     const peopleAPI = google.people({
@@ -102,18 +98,14 @@ module.exports = (() => ({
       auth: this.oAuth2Client
     })
 
-    try {
-      return peopleAPI.people.updateContact({
-        resourceName,
-        requestBody: {
-          ...person,
-          etag
-        },
-        updatePersonFields: Object.keys(person).join(',')
-      })
-    } catch (err) {
-      throw new Error(`Unable to update contact ${err.message}`)
-    }
+    return peopleAPI.people.updateContact({
+      resourceName,
+      requestBody: {
+        ...person,
+        etag
+      },
+      updatePersonFields: Object.keys(person).join(',')
+    })
   },
   deleteContact: function(resourceName) {
     const peopleAPI = google.people({
@@ -121,12 +113,8 @@ module.exports = (() => ({
       auth: this.oAuth2Client
     })
 
-    try {
-      return peopleAPI.people.deleteContact({
-        resourceName
-      })
-    } catch (err) {
-      throw new Error(`Unable to delete contact ${err.message}`)
-    }
+    return peopleAPI.people.deleteContact({
+      resourceName
+    })
   }
 }))()

--- a/src/index.js
+++ b/src/index.js
@@ -106,23 +106,15 @@ async function start(fields, doRetry = true) {
 
     log(
       'info',
-      `Created ${result.cozy.created} new Cozy contacts for ${accountEmail}`
+      `${result.cozy.created} created / ${result.cozy.updated} updated / ${
+        result.cozy.deleted
+      } deleted contacts on Cozy for ${accountEmail}`
     )
     log(
       'info',
-      `Created ${result.google.created} new Google contacts for ${accountEmail}`
-    )
-    log(
-      'info',
-      `Updated ${result.cozy.updated} Cozy contacts for ${accountEmail}`
-    )
-    log(
-      'info',
-      `Updated ${result.google.updated} Google contacts for ${accountEmail}`
-    )
-    log(
-      'info',
-      `Deleted ${result.cozy.deleted} Cozy contacts for ${accountEmail}`
+      `${result.google.created} created / ${result.google.updated} updated / ${
+        result.google.deleted
+      } deleted contacts on Google for ${accountEmail}`
     )
 
     // update the contact account

--- a/src/synchronizeContacts.spec.js
+++ b/src/synchronizeContacts.spec.js
@@ -83,6 +83,30 @@ const cozyContacts = [
         }
       }
     }
+  },
+  {
+    id: 'fabiola-grozdana-deleted-on-cozy',
+    _type: 'io.cozy.contacts',
+    _rev: '678aad8-fa2b-482c-b9b9-8768bcfe3',
+    trashed: true,
+    name: { givenName: 'Fabiola', familyName: 'Grozdana' },
+    cozyMetadata: {
+      doctypeVersion: 2,
+      createdAt: '2017-03-22T07:33:00.123Z',
+      createdByApp: 'Contacts',
+      createdByAppVersion: '2.0.0',
+      updatedAt: '2018-11-12T18:18:00.222Z',
+      updatedByApps: ['Contacts', 'konnector-google'],
+      importedAt: '2016-11-25T19:33:00.123Z',
+      importedFrom: 'Contacts',
+      sourceAccount: SOURCE_ACCOUNT_ID,
+      sync: {
+        [SOURCE_ACCOUNT_ID]: {
+          id: 'people/924609',
+          remoteRev: 'ea79ad60-8c9f-4143-830f-07dfb260630b'
+        }
+      }
+    }
   }
 ]
 
@@ -165,6 +189,12 @@ describe('synchronizeContacts function', () => {
       data: {
         etag: '6020dd2f-c9b8-4865-bdbd-078faad65204',
         resourceName: 'people/987654' // john-doe-edited
+      }
+    })
+    googleUtils.deleteContact.mockResolvedValueOnce({
+      data: {
+        etag: '440922abef-c9b8-4865-bdbd-85561aa7b',
+        resourceName: 'people/924609' // fabiola-grozdana-deleted-in-cozy
       }
     })
     fakeCozyClient.save = jest
@@ -259,12 +289,12 @@ describe('synchronizeContacts function', () => {
     expect(result).toEqual({
       cozy: {
         created: 2,
-        deleted: 1,
+        deleted: 2,
         updated: 1
       },
       google: {
         created: 2,
-        deleted: 0,
+        deleted: 1,
         updated: 1
       }
     })
@@ -288,8 +318,11 @@ describe('synchronizeContacts function', () => {
       'scarlettKundeInCozy'
     )
 
-    expect(fakeCozyClient.destroy).toHaveBeenCalledTimes(1)
+    expect(fakeCozyClient.destroy).toHaveBeenCalledTimes(2)
     expect(fakeCozyClient.destroy.mock.calls[0]).toMatchSnapshot(
+      'destroyFabiolaGrozdanaInCozy'
+    )
+    expect(fakeCozyClient.destroy.mock.calls[1]).toMatchSnapshot(
       'destroyAureliaHayesInCozy'
     )
 
@@ -304,6 +337,11 @@ describe('synchronizeContacts function', () => {
     expect(googleUtils.updateContact).toHaveBeenCalledTimes(1)
     expect(googleUtils.updateContact.mock.calls[0]).toMatchSnapshot(
       'johnDoeInGoogle'
+    )
+
+    expect(googleUtils.deleteContact).toHaveBeenCalledTimes(1)
+    expect(googleUtils.deleteContact.mock.calls[0]).toMatchSnapshot(
+      'fabiolaGrozdanaInGoogle'
     )
   })
 


### PR DESCRIPTION
Based on https://github.com/konnectors/cozy-konnector-google/pull/252 — deleting a trashed cozy-contact on google (and then on cozy).

Not sure why I needed a snapshot update there though?