### PR TITLE
Ask for a new sync token after sync if we changed something on google side

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -54,7 +54,7 @@ async function start(fields, doRetry = true) {
 
     log('info', 'Getting all the contacts')
     const [
-      { contacts: googleContacts, nextSyncToken },
+      { contacts: googleContacts, nextSyncToken: syncTokenBefore },
       cozyContacts
     ] = await Promise.all([
       googleUtils.getAllContacts({
@@ -62,7 +62,6 @@ async function start(fields, doRetry = true) {
       }),
       cozyUtils.getUpdatedContacts(contactAccount.lastLocalSync)
     ])
-    const lastGoogleSync = new Date().toISOString()
 
     log(
       'info',
@@ -79,6 +78,25 @@ async function start(fields, doRetry = true) {
       googleUtils
     )
 
+    // update the contact account
+    const lastLocalSync = new Date().toISOString()
+    let nextSyncToken = syncTokenBefore
+    // if we changed something on google, we have to ask for a new sync token
+    if (Object.values(result.google).some(v => v !== 0)) {
+      const response = await googleUtils.getAllContacts({
+        syncToken: syncTokenBefore
+      })
+      nextSyncToken = response.nextSyncToken
+    }
+    const lastGoogleSync = new Date().toISOString()
+
+    await cozyUtils.save({
+      ...contactAccount,
+      lastSync: lastGoogleSync,
+      lastLocalSync: lastLocalSync,
+      syncToken: nextSyncToken
+    })
+
     log(
       'info',
       `${result.cozy.created} created / ${result.cozy.updated} updated / ${
@@ -91,15 +109,6 @@ async function start(fields, doRetry = true) {
         result.google.deleted
       } deleted contacts on Google for ${accountEmail}`
     )
-
-    // update the contact account
-    const lastLocalSync = new Date().toISOString()
-    await cozyUtils.save({
-      ...contactAccount,
-      lastSync: lastGoogleSync,
-      lastLocalSync: lastLocalSync,
-      syncToken: nextSyncToken
-    })
     log('info', 'Sync has completed successfully')
   } catch (err) {
     if (err.code === 401 || err.code === 403) {

--- a/src/index.js
+++ b/src/index.js
@@ -87,6 +87,14 @@ async function start(fields, doRetry = true) {
         syncToken: syncTokenBefore
       })
       nextSyncToken = response.nextSyncToken
+      const contactsWeUpdated = result.google.created + result.google.updated
+      if (response.contacts.length !== contactsWeUpdated) {
+        log(
+          'warn',
+          'User has created/updated contacts on google during the synchronization ' +
+            '(some cozy changes may be lost next time).'
+        )
+      }
     }
     const lastGoogleSync = new Date().toISOString()
 


### PR DESCRIPTION
We had an issue with this scenario: 
- edit a contact on cozy
- run sync (the contact is updated on google)
- edit the same contact on cozy
- run sync

=> we have the contact both in `cozyContacts` and `googleContacts` so the contact is updated on cozy (instead of google) and we lose the data that we just changed on the contact.

It happened before we use the `syncToken` that we got in response to the google query to retrieve the contacts so the contact(s) we updated on google during sync were in the response of the next query.

This is a simple solution but maybe it should work if we just call `getConnectionsList` (no pagination) with only one field (we would have to revert some of the changes we made yesterday). I'm not sure that it worth it since we just retrieve contacts that we changed with the current sync. Opinions?