### PR TITLE
New fixes on google sync

### DIFF
--- a/src/__snapshots__/synchronizeContacts.spec.js.snap
+++ b/src/__snapshots__/synchronizeContacts.spec.js.snap
@@ -221,6 +221,45 @@ Array [
 ]
 `;
 
+exports[`synchronizeContacts function should synchronize contacts: destroyRodTrompInCozy 1`] = `
+Array [
+  Object {
+    "_rev": "af1cd883-216b-42eb-9766-d54ebed38658",
+    "_type": "io.cozy.contacts",
+    "address": Array [],
+    "birthday": null,
+    "company": null,
+    "cozyMetadata": Object {
+      "createdAt": "2018-04-22T17:33:00.123Z",
+      "createdByApp": "Contacts",
+      "createdByAppVersion": "2.0.0",
+      "doctypeVersion": 2,
+      "sourceAccount": "45c49c15-4b00-48e8-8bfd-29f8177b89ff",
+      "updatedAt": "2018-12-22T15:18:00.222Z",
+      "updatedByApps": Array [
+        "Contacts",
+        "konnector-google",
+      ],
+    },
+    "email": Array [],
+    "id": "deleted-on-cozy-no-resource-name",
+    "metadata": Object {
+      "google": Object {
+        "metadata": null,
+      },
+      "version": 1,
+    },
+    "name": Object {
+      "familyName": "Tromp",
+      "givenName": "Rod",
+    },
+    "note": null,
+    "phone": Array [],
+    "trashed": true,
+  },
+]
+`;
+
 exports[`synchronizeContacts function should synchronize contacts: fabiolaGrozdanaInGoogle 1`] = `
 Array [
   "people/924609",

--- a/src/synchronizeContacts.js
+++ b/src/synchronizeContacts.js
@@ -266,8 +266,14 @@ const synchronizeContacts = async (
           const { id: resourceName } = cozyContact.cozyMetadata.sync[
             contactAccountId
           ]
-          await googleUtils.deleteContact(resourceName)
-          result.google.deleted++
+          try {
+            await googleUtils.deleteContact(resourceName)
+            result.google.deleted++
+          } catch (err) {
+            if (err.code !== 404) {
+              throw err
+            }
+          }
           await cozyUtils.client.destroy(mergedContact)
           result.cozy.deleted++
         } else {

--- a/src/synchronizeContacts.js
+++ b/src/synchronizeContacts.js
@@ -129,10 +129,10 @@ const determineActionOnGoogle = (cozyContact, contactAccountId) => {
   const syncInfo = get(cozyContact, `cozyMetadata.sync.${contactAccountId}`)
   const isTrashedOnCozy = cozyContact.trashed
 
-  if (!syncInfo) {
-    return SHOULD_CREATE
-  } else if (isTrashedOnCozy) {
+  if (isTrashedOnCozy) {
     return SHOULD_DELETE
+  } else if (!syncInfo) {
+    return SHOULD_CREATE
   } else {
     return SHOULD_UPDATE
   }

--- a/src/synchronizeContacts.js
+++ b/src/synchronizeContacts.js
@@ -263,17 +263,24 @@ const synchronizeContacts = async (
           )
           result.google.created++
         } else if (action === SHOULD_DELETE) {
-          const { id: resourceName } = cozyContact.cozyMetadata.sync[
-            contactAccountId
-          ]
-          try {
-            await googleUtils.deleteContact(resourceName)
-            result.google.deleted++
-          } catch (err) {
-            if (err.code !== 404) {
-              throw err
+          const resourceName = get(cozyContact, [
+            'cozyMetadata',
+            'sync',
+            contactAccountId,
+            'id'
+          ])
+
+          if (resourceName) {
+            try {
+              await googleUtils.deleteContact(resourceName)
+              result.google.deleted++
+            } catch (err) {
+              if (err.code !== 404) {
+                throw err
+              }
             }
           }
+
           await cozyUtils.client.destroy(mergedContact)
           result.cozy.deleted++
         } else {

--- a/src/synchronizeContacts.spec.js
+++ b/src/synchronizeContacts.spec.js
@@ -152,6 +152,22 @@ const cozyContacts = [
         }
       }
     }
+  },
+  {
+    id: 'deleted-on-cozy-no-resource-name',
+    _type: 'io.cozy.contacts',
+    _rev: 'af1cd883-216b-42eb-9766-d54ebed38658',
+    trashed: true,
+    name: { givenName: 'Rod', familyName: 'Tromp' },
+    cozyMetadata: {
+      doctypeVersion: 2,
+      createdAt: '2018-04-22T17:33:00.123Z',
+      createdByApp: 'Contacts',
+      createdByAppVersion: '2.0.0',
+      updatedAt: '2018-12-22T15:18:00.222Z',
+      updatedByApps: ['Contacts', 'konnector-google'],
+      sourceAccount: SOURCE_ACCOUNT_ID
+    }
   }
 ]
 
@@ -344,7 +360,7 @@ describe('synchronizeContacts function', () => {
     expect(result).toEqual({
       cozy: {
         created: 2,
-        deleted: 3,
+        deleted: 4,
         updated: 2
       },
       google: {
@@ -378,7 +394,7 @@ describe('synchronizeContacts function', () => {
     )
     expect(fakeCozyClient.save.mock.calls[6]).toMatchSnapshot('johnDoeInCozy')
 
-    expect(fakeCozyClient.destroy).toHaveBeenCalledTimes(3)
+    expect(fakeCozyClient.destroy).toHaveBeenCalledTimes(4)
 
     expect(fakeCozyClient.destroy.mock.calls[0]).toMatchSnapshot(
       'destroyAureliaHayesInCozy'
@@ -389,6 +405,10 @@ describe('synchronizeContacts function', () => {
     )
 
     expect(fakeCozyClient.destroy.mock.calls[2]).toMatchSnapshot(
+      'destroyRodTrompInCozy'
+    )
+
+    expect(fakeCozyClient.destroy.mock.calls[3]).toMatchSnapshot(
       'destroyFabiolaGrozdanaInCozy'
     )
 


### PR DESCRIPTION
- Do not crash if a contact deleted on cozy has already been deleted on google
- Don't create contacts that has been deleted on cozy
- Don't even try to delete google contact if no resource name can be found