### PR TITLE
fix: Transpile empty strings to empty arrays for google

### DIFF
--- a/sample/io.cozy.contacts.json
+++ b/sample/io.cozy.contacts.json
@@ -87,7 +87,9 @@
           { "address": "isabelle.milligan@cirpria.name", "primary": true }
         ],
         "name": { "familyName": "Milligan", "givenName": "Isabelle" },
-        "phone": [{ "number": "+33 (0)7 56 74 51 43", "primary": true }]
+        "phone": [{ "number": "+33 (0)7 56 74 51 43", "primary": true }],
+        "company": "",
+        "note": ""
       }
     }
   ]

--- a/src/__snapshots__/synchronizeContacts.spec.js.snap
+++ b/src/__snapshots__/synchronizeContacts.spec.js.snap
@@ -326,7 +326,7 @@ exports[`synchronizeContacts function should synchronize contacts: johnDoeInGoog
 Array [
   Object {
     "addresses": Array [],
-    "biographies": null,
+    "biographies": Array [],
     "birthdays": Array [
       Object {
         "date": Object {
@@ -468,7 +468,7 @@ exports[`synchronizeContacts function should synchronize contacts: larueCreminIn
 Array [
   Object {
     "addresses": Array [],
-    "biographies": null,
+    "biographies": Array [],
     "birthdays": Array [],
     "emailAddresses": Array [],
     "names": Array [
@@ -477,7 +477,7 @@ Array [
         "givenName": "Larue",
       },
     ],
-    "organizations": null,
+    "organizations": Array [],
     "phoneNumbers": Array [],
   },
 ]
@@ -531,7 +531,7 @@ exports[`synchronizeContacts function should synchronize contacts: reinholdJenki
 Array [
   Object {
     "addresses": Array [],
-    "biographies": null,
+    "biographies": Array [],
     "birthdays": Array [],
     "emailAddresses": Array [],
     "names": Array [
@@ -540,7 +540,7 @@ Array [
         "givenName": "Reinhold",
       },
     ],
-    "organizations": null,
+    "organizations": Array [],
     "phoneNumbers": Array [],
   },
 ]

--- a/src/transpiler.js
+++ b/src/transpiler.js
@@ -168,22 +168,22 @@ function getBirthdays({ birthday = null }) {
 }
 
 function getOrganizations({ company = undefined }) {
-  return (
-    company && [
-      {
-        name: company
-      }
-    ]
-  )
+  return company
+    ? [
+        {
+          name: company
+        }
+      ]
+    : []
 }
 
 function getBiographies({ note = undefined }) {
-  return (
-    note && [
-      {
-        contentType: 'TEXT_PLAIN',
-        value: note
-      }
-    ]
-  )
+  return note
+    ? [
+        {
+          contentType: 'TEXT_PLAIN',
+          value: note
+        }
+      ]
+    : []
 }

--- a/src/transpiler.spec.js
+++ b/src/transpiler.spec.js
@@ -170,4 +170,40 @@ describe('Transpile from io.cozy.contacts to google-contacts', () => {
     const actual = transpile.toGoogle(johnDoeContact)
     expect(actual).toEqual(expected)
   })
+
+  it('should transpile a cozy contact with empty values to a valid google person', () => {
+    const cozyContact = {
+      name: {
+        givenName: 'Keyon',
+        familyName: 'Lemke'
+      },
+      fullname: 'Keyon Lemke',
+      address: [],
+      cozy: [],
+      email: [],
+      phone: [],
+      company: '',
+      note: '',
+      metadata: {
+        cozy: true,
+        version: 1
+      }
+    }
+    const expected = {
+      addresses: [],
+      biographies: [],
+      birthdays: [],
+      emailAddresses: [],
+      names: [
+        {
+          givenName: 'Keyon',
+          familyName: 'Lemke'
+        }
+      ],
+      organizations: [],
+      phoneNumbers: []
+    }
+    const actual = transpile.toGoogle(cozyContact)
+    expect(actual).toEqual(expected)
+  })
 })


### PR DESCRIPTION
People API expect arrays and not strings. Since https://github.com/cozy/cozy-contacts/commit/a2d034eb644c1673762b64642efda459150ca730 transpilation failed.