### PR TITLE
fix: Don't erase other relationships on accounts relationship update

### DIFF
--- a/src/__snapshots__/synchronizeContacts.spec.js.snap
+++ b/src/__snapshots__/synchronizeContacts.spec.js.snap
@@ -107,6 +107,12 @@ Array [
           },
         ],
       },
+      "groups": Object {
+        "data": Object {
+          "_id": "ba36efdf-f09b-41cf-ba6b-eb137214d676",
+          "_type": "io.cozy.contacts.groups",
+        },
+      },
     },
   },
 ]

--- a/src/synchronizeContacts.js
+++ b/src/synchronizeContacts.js
@@ -80,6 +80,7 @@ const updateCozyMetadata = (
 const updateAccountsRelationship = (contact, contactAccountId) => ({
   ...contact,
   relationships: {
+    ...contact.relationships,
     accounts: {
       data: uniqBy(
         [

--- a/src/synchronizeContacts.spec.js
+++ b/src/synchronizeContacts.spec.js
@@ -107,6 +107,14 @@ const cozyContacts = [
           remoteRev: '5c3435d9-86cb-413f-b38a-fd941fa3ec8d'
         }
       }
+    },
+    relationships: {
+      groups: {
+        data: {
+          _id: 'ba36efdf-f09b-41cf-ba6b-eb137214d676',
+          _type: 'io.cozy.contacts.groups'
+        }
+      }
     }
   },
   {


### PR DESCRIPTION
`updateAccountsRelationship` was erasing other relationships