### PR TITLE
fix: Init relationships in cozy

### DIFF
--- a/src/__snapshots__/synchronizeContacts.spec.js.snap
+++ b/src/__snapshots__/synchronizeContacts.spec.js.snap
@@ -466,6 +466,16 @@ Array [
     },
     "note": null,
     "phone": Array [],
+    "relationships": Object {
+      "accounts": Object {
+        "data": Array [
+          Object {
+            "_id": "45c49c15-4b00-48e8-8bfd-29f8177b89ff",
+            "_type": "io.cozy.contacts.accounts",
+          },
+        ],
+      },
+    },
   },
 ]
 `;
@@ -529,6 +539,22 @@ Array [
     },
     "note": null,
     "phone": Array [],
+    "relationships": Object {
+      "accounts": Object {
+        "data": Array [
+          Object {
+            "_id": "45c49c15-4b00-48e8-8bfd-29f8177b89ff",
+            "_type": "io.cozy.contacts.accounts",
+          },
+        ],
+      },
+      "groups": Object {
+        "data": Object {
+          "_id": "ba36efdf-f09b-41cf-ba6b-eb137214d676",
+          "_type": "io.cozy.contacts.groups",
+        },
+      },
+    },
   },
 ]
 `;

--- a/src/synchronizeContacts.js
+++ b/src/synchronizeContacts.js
@@ -262,6 +262,10 @@ const synchronizeContacts = async (
             resourceName,
             contactAccountId
           )
+          mergedContact = updateAccountsRelationship(
+            mergedContact,
+            contactAccountId
+          )
           result.google.created++
         } else if (action === SHOULD_DELETE) {
           const resourceName = get(cozyContact, [

--- a/src/synchronizeContacts.spec.js
+++ b/src/synchronizeContacts.spec.js
@@ -25,6 +25,14 @@ const cozyContacts = [
       updatedAt: '2018-11-11T09:09:00.222Z',
       updatedByApps: ['Contacts'],
       sourceAccount: undefined
+    },
+    relationships: {
+      groups: {
+        data: {
+          _id: 'ba36efdf-f09b-41cf-ba6b-eb137214d676',
+          _type: 'io.cozy.contacts.groups'
+        }
+      }
     }
   },
   {


### PR DESCRIPTION
After creating a cozy-contact in google, we didn't init the relationships field.