### PR TITLE
Set sourceAccount to null on the contact account when the account is deleted

### DIFF
--- a/manifest.konnector
+++ b/manifest.konnector
@@ -74,5 +74,6 @@
       }
     }
   },
-  "manifest_version": "2"
+  "manifest_version": "2",
+  "on_delete_account": "onDeleteAccount.js"
 }

--- a/src/CozyUtils.js
+++ b/src/CozyUtils.js
@@ -148,6 +148,15 @@ class CozyUtils {
     return get(resp, 'data.0')
   }
 
+  async findContactAccount(accountId) {
+    const accountsCollection = this.client.collection(DOCTYPE_CONTACTS_ACCOUNT)
+    const result = await accountsCollection.find({
+      sourceAccount: accountId
+    })
+
+    return get(result.data, 0, null)
+  }
+
   async findOrCreateContactAccount(accountId, accountEmail) {
     const accountsCollection = this.client.collection(DOCTYPE_CONTACTS_ACCOUNT)
     const accountsWithSourceAccount = await accountsCollection.find({

--- a/src/helpers/getAccountId.js
+++ b/src/helpers/getAccountId.js
@@ -1,0 +1,11 @@
+function getAccountId() {
+  try {
+    return process.env.NODE_ENV === 'development'
+      ? 'fakeAccountId'
+      : JSON.parse(process.env.COZY_FIELDS).account
+  } catch (err) {
+    throw new Error(`You must provide 'account' in COZY_FIELDS: ${err.message}`)
+  }
+}
+
+module.exports = getAccountId

--- a/src/index.js
+++ b/src/index.js
@@ -11,17 +11,8 @@ const {
 
 const CozyUtils = require('./CozyUtils')
 const GoogleUtils = require('./GoogleUtils')
+const getAccountId = require('./helpers/getAccountId')
 const synchronizeContacts = require('./synchronizeContacts')
-
-function getAccountId() {
-  try {
-    return process.env.NODE_ENV === 'development'
-      ? 'fakeAccountId'
-      : JSON.parse(process.env.COZY_FIELDS).account
-  } catch (err) {
-    throw new Error(`You must provide 'account' in COZY_FIELDS: ${err.message}`)
-  }
-}
 
 module.exports = new BaseKonnector(start)
 

--- a/src/onDeleteAccount.js
+++ b/src/onDeleteAccount.js
@@ -1,0 +1,30 @@
+const { log } = require('cozy-konnector-libs')
+
+const getAccountId = require('./helpers/getAccountId')
+const CozyUtils = require('./CozyUtils')
+
+async function onDeleteAccount() {
+  log('info', 'onDeleteAccount: remove account id from the contact account')
+  const accountId = getAccountId()
+  const cozyUtils = new CozyUtils(accountId)
+  const contactAccount = await cozyUtils.findContactAccount(accountId)
+  contactAccount.sourceAccount = null
+  await cozyUtils.client.save(contactAccount)
+}
+
+onDeleteAccount().then(
+  () => {
+    log(
+      'info',
+      'onDeleteAccount: Successfully marked the io.cozy.contacts.accounts as inactive'
+    )
+  },
+  err => {
+    log(
+      'error',
+      `onDeleteAccount: An error occured during onDeleteAccount script: ${
+        err.message
+      }`
+    )
+  }
+)

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,7 +3,7 @@ const CopyPlugin = require('copy-webpack-plugin')
 const fs = require('fs')
 const SvgoInstance = require('svgo')
 
-const entry = require('./package.json').main
+const index = require('./package.json').main
 
 const svgo = new SvgoInstance()
 
@@ -18,12 +18,15 @@ try {
 const appIconRX = iconName && new RegExp(`[^/]*/${iconName}`)
 
 module.exports = {
-  entry,
+  entry: {
+    index,
+    onDeleteAccount: './src/onDeleteAccount.js'
+  },
   target: 'node',
   mode: 'none',
   output: {
     path: path.join(__dirname, 'build'),
-    filename: 'index.js'
+    filename: '[name].js'
   },
   plugins: [
     new CopyPlugin([


### PR DESCRIPTION
Set `sourceAccount` to `null` on the `io.cozy.contacts.accounts` when the `io.cozy.accounts` is disconnected

Thus, the Contacts app can know if the account has been disconneted and then don't display the source related to this account.