### PR TITLE
Fix synchronization

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -138,6 +138,9 @@ async function start(fields, doRetry = true) {
         log('info', JSON.stringify(body))
         fields.access_token = body.attributes.oauth.access_token
         return start(fields, false)
+      } else {
+        log('info', `Error during authentication ${err.message}`)
+        throw errors.USER_ACTION_NEEDED_OAUTH_OUTDATED
       }
     } else {
       log('error', 'caught an unexpected error')

--- a/src/synchronizeContacts.js
+++ b/src/synchronizeContacts.js
@@ -330,6 +330,7 @@ const synchronizeContacts = async (
 
     return result
   } catch (err) {
+    log('error', `Error during sync: ${err.message}`)
     throw new Error(`Unable to synchronize contacts: ${err.message}`)
   }
 }


### PR DESCRIPTION
- Fix bug with auth: throw `USER_ACTION_NEEDED_OAUTH_OUTDATED` if we have any `401` or `403` (e.g Invalid credentials) and refresh/retry has failed/is deactivated
- Add more logs
- Avoid total failure if contact is not found on Google