### PR TITLE
fix: Never fail silently on auth error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -143,10 +143,10 @@ async function start(fields, doRetry = true) {
           fields.access_token = body.attributes.oauth.access_token
           return start(fields, false)
         }
-      } else {
-        log('error', `Error during authentication ${err.message}`)
-        throw errors.VENDOR_DOWN
       }
+
+      log('error', `Error during authentication: ${err.message}`)
+      throw errors.VENDOR_DOWN
     } else {
       log('error', 'caught an unexpected error')
       log('error', err.message)


### PR DESCRIPTION
If an error is catched, we should at least throw `VENDOR_DOWN` (there was a case where no error was thrown `Konnector success`)