### PR TITLE
fix: Allow konnector to update io.cozy.accounts

### DIFF
--- a/manifest.konnector
+++ b/manifest.konnector
@@ -31,7 +31,7 @@
     },
     "accounts": {
       "type": "io.cozy.accounts",
-      "verbs": ["GET"]
+      "verbs": ["GET", "POST"]
     },
     "contactsAccounts": {
       "type": "io.cozy.contacts.accounts"


### PR DESCRIPTION
We need write permission on accounts to be able to update `accountName`