### PR TITLE
fix: Use PATCH instead of POST to allow update on accounts

### DIFF
--- a/manifest.konnector
+++ b/manifest.konnector
@@ -31,7 +31,7 @@
     },
     "accounts": {
       "type": "io.cozy.accounts",
-      "verbs": ["GET", "POST"]
+      "verbs": ["GET", "PATCH"]
     },
     "contactsAccounts": {
       "type": "io.cozy.contacts.accounts"


### PR DESCRIPTION
`POST` does not seem to work, try `PATCH` instead