### PR TITLE
fix: Do not use verbs, just allow ALL on io.cozy.accounts

### DIFF
--- a/manifest.konnector
+++ b/manifest.konnector
@@ -30,8 +30,7 @@
       "type": "io.cozy.contacts"
     },
     "accounts": {
-      "type": "io.cozy.accounts",
-      "verbs": ["GET", "POST"]
+      "type": "io.cozy.accounts"
     },
     "contactsAccounts": {
       "type": "io.cozy.contacts.accounts"


### PR DESCRIPTION
Well, it seems that PATCH is not good either...
See https://github.com/konnectors/cozy-konnector-google/pull/310 and https://github.com/konnectors/cozy-konnector-google/pull/311
