### PR TITLE
fix: Do not use verbs, just allow ALL on io.cozy.accounts

### DIFF
--- a/manifest.konnector
+++ b/manifest.konnector
@@ -30,8 +30,7 @@
       "type": "io.cozy.contacts"
     },
     "accounts": {
-      "type": "io.cozy.accounts",
-      "verbs": ["GET", "PATCH"]
+      "type": "io.cozy.accounts"
     },
     "contactsAccounts": {
       "type": "io.cozy.contacts.accounts"


### PR DESCRIPTION
Don't use verbs as we still get `Forbidden` errors from the stack.