### PR TITLE
Limit number of concurrent promises at the same time

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "cozy-client": "6.19.0",
     "cozy-konnector-libs": "4.14.13",
     "googleapis": "36.0.0",
-    "json-loader": "0.5.7"
+    "json-loader": "0.5.7",
+    "p-limit": "2.2.0"
   },
   "devDependencies": {
     "chalk": "2.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6197,6 +6197,13 @@ p-limit@^2.0.0:
   dependencies:
     p-try "^2.0.0"
 
+p-limit@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.2.0.tgz#417c9941e6027a9abcba5092dd2904e255b5fbc2"
+  integrity sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==
+  dependencies:
+    p-try "^2.0.0"
+
 p-locate@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"


### PR DESCRIPTION
Use p-limit : https://www.npmjs.com/package/p-limit
The number of concurrent promises is defined by `const limit = pLimit(10)`. Maybe we could put this number in a constant?