### PR TITLE
Add more logs and higher promises limit

### DIFF
--- a/src/CozyUtils.js
+++ b/src/CozyUtils.js
@@ -93,6 +93,7 @@ class CozyUtils {
   async getUpdatedContacts(contactAccount) {
     const { id: contactAccountId, lastSync, shouldSyncOrphan } = contactAccount
     let allContacts = []
+    log('info', 'Get updated Cozy contacts: start')
     const contactsCollection = this.client.collection(DOCTYPE_CONTACTS)
     let hasMore = true
     while (hasMore) {
@@ -126,6 +127,7 @@ class CozyUtils {
         }
       }
 
+      log('info', 'Get updated Cozy contacts: ask for more contacts')
       const resp = await contactsCollection.find(query, {
         indexedFields: ['cozyMetadata.updatedAt']
       })
@@ -133,6 +135,7 @@ class CozyUtils {
       hasMore = resp.next
     }
 
+    log('info', 'Get updated Cozy contacts: done')
     return allContacts
   }
 

--- a/src/GoogleUtils.js
+++ b/src/GoogleUtils.js
@@ -1,4 +1,5 @@
 const { google } = require('googleapis')
+const { log } = require('cozy-konnector-libs')
 const OAuth2Client = google.auth.OAuth2
 
 // see https://developers.google.com/apis-explorer/#search/people/people/v1/people.people.connections.list
@@ -91,12 +92,15 @@ class GoogleUtils {
         requestSyncToken: true,
         syncToken
       })
-      if (call.connections == null || call.connections.length === 0)
+      if (call.connections == null || call.connections.length === 0) {
+        log('info', 'Get all google contacts: empty')
         return {
           contacts: [],
           nextSyncToken: call.nextSyncToken
         }
+      }
       if (call.nextPageToken) {
+        log('info', 'Get all google contacts: ask for a next page')
         const nextPageResult = await this.getAllContacts({
           pageToken: call.nextPageToken,
           requestSyncToken: true,
@@ -107,6 +111,7 @@ class GoogleUtils {
           nextSyncToken: nextPageResult.nextSyncToken
         }
       } else {
+        log('info', 'Get all google contacts: last page')
         return {
           contacts: call.connections,
           nextSyncToken: call.nextSyncToken

--- a/src/synchronizeContacts.js
+++ b/src/synchronizeContacts.js
@@ -177,7 +177,7 @@ const synchronizeContacts = async (
       deleted: 0
     }
   }
-  const limit = pLimit(10)
+  const limit = pLimit(50)
   try {
     await cozyUtils.prepareIndex(contactAccountId)
 


### PR DESCRIPTION
- add more logs in `getAllContacts` (google) and `getUpdatedContacts` (cozy) to debug infinite loops or pagination errors
- update promises limit to 50