### PR TITLE
fix: Really use pagination on getUpdatedContacts

### DIFF
--- a/src/CozyUtils.js
+++ b/src/CozyUtils.js
@@ -90,13 +90,12 @@ class CozyUtils {
       .createIndex([`cozyMetadata.sync.${contactAccountId}.id`])
   }
 
-  async getUpdatedContacts(contactAccount) {
+  async getUpdatedContacts(contactAccount, limit = 100) {
     const { id: contactAccountId, lastSync, shouldSyncOrphan } = contactAccount
     let allContacts = []
     log('info', 'Get updated Cozy contacts: start')
     const contactsCollection = this.client.collection(DOCTYPE_CONTACTS)
     let hasMore = true
-    const LIMIT = 100
     let skip = 0
     while (hasMore) {
       const query = {
@@ -134,12 +133,12 @@ class CozyUtils {
       const resp = await contactsCollection.find(query, {
         indexedFields: ['cozyMetadata.updatedAt'],
         skip: skip,
-        limit: LIMIT
+        limit: limit
       })
 
       allContacts = [...allContacts, ...resp.data]
       hasMore = resp.next
-      skip += LIMIT
+      skip += limit
     }
 
     log('info', 'Get updated Cozy contacts: done')

--- a/src/CozyUtils.js
+++ b/src/CozyUtils.js
@@ -96,6 +96,8 @@ class CozyUtils {
     log('info', 'Get updated Cozy contacts: start')
     const contactsCollection = this.client.collection(DOCTYPE_CONTACTS)
     let hasMore = true
+    const LIMIT = 100
+    let skip = 0
     while (hasMore) {
       const query = {
         cozyMetadata: {
@@ -128,11 +130,16 @@ class CozyUtils {
       }
 
       log('info', 'Get updated Cozy contacts: ask for more contacts')
+
       const resp = await contactsCollection.find(query, {
-        indexedFields: ['cozyMetadata.updatedAt']
+        indexedFields: ['cozyMetadata.updatedAt'],
+        skip: skip,
+        limit: LIMIT
       })
+
       allContacts = [...allContacts, ...resp.data]
       hasMore = resp.next
+      skip += LIMIT
     }
 
     log('info', 'Get updated Cozy contacts: done')

--- a/src/CozyUtils.spec.js
+++ b/src/CozyUtils.spec.js
@@ -129,7 +129,9 @@ describe('CozyUtils', () => {
           }
         },
         {
-          indexedFields: ['cozyMetadata.updatedAt']
+          indexedFields: ['cozyMetadata.updatedAt'],
+          limit: 100,
+          skip: 0
         }
       )
     })
@@ -182,7 +184,9 @@ describe('CozyUtils', () => {
           }
         },
         {
-          indexedFields: ['cozyMetadata.updatedAt']
+          indexedFields: ['cozyMetadata.updatedAt'],
+          limit: 100,
+          skip: 0
         }
       )
     })

--- a/src/CozyUtils.spec.js
+++ b/src/CozyUtils.spec.js
@@ -136,6 +136,46 @@ describe('CozyUtils', () => {
       )
     })
 
+    it('should get all updated contacts even with pagination', async () => {
+      const findSpy = jest.fn()
+      // first page
+      findSpy.mockResolvedValueOnce({
+        data: [
+          {
+            id: 'john-doe'
+          }
+        ],
+        next: true
+      })
+      // second page
+      findSpy.mockResolvedValueOnce({
+        data: [
+          {
+            id: 'pierre-durand'
+          }
+        ],
+        next: false
+      })
+      cozyUtils.client.collection = jest.fn(() => ({
+        find: findSpy
+      }))
+      const contactAccount = {
+        id: 'fakeAccountId',
+        lastSync: '2018-04-03T15:16:02.276Z',
+        shouldSyncOrphan: false
+      }
+      const result = await cozyUtils.getUpdatedContacts(contactAccount, 1)
+      expect(result).toEqual([
+        {
+          id: 'john-doe'
+        },
+        {
+          id: 'pierre-durand'
+        }
+      ])
+      expect(findSpy).toHaveBeenCalledTimes(2)
+    })
+
     it('should get all updated contacts including orphans', async () => {
       const findSpy = jest.fn()
       findSpy.mockResolvedValueOnce({


### PR DESCRIPTION
Use `limit` and `skip` to query cozy contacts by 100 and avoid infinite queries