### PR TITLE
Delete contact from cozy if it has been hidden from google

### DIFF
--- a/src/GoogleUtils.js
+++ b/src/GoogleUtils.js
@@ -163,6 +163,20 @@ class GoogleUtils {
     })
     return response.data
   }
+
+  async getContact(resourceName, personFields = ['names']) {
+    const peopleAPI = google.people({
+      version: 'v1',
+      auth: this.oAuth2Client
+    })
+
+    const response = await peopleAPI.people.get({
+      resourceName,
+      personFields
+    })
+
+    return response.data
+  }
 }
 
 module.exports = GoogleUtils

--- a/src/GoogleUtils.spec.js
+++ b/src/GoogleUtils.spec.js
@@ -8,6 +8,7 @@ describe('GoogleUtils', () => {
   const peopleAPIMock = googleapis.google.people()
   const googleCreateContactSpy = peopleAPIMock.people.createContact
   const googleUpdateContactSpy = peopleAPIMock.people.updateContact
+  const googleGetContactSpy = peopleAPIMock.people.get
 
   afterEach(() => {
     jest.clearAllMocks()
@@ -100,6 +101,20 @@ describe('GoogleUtils', () => {
         resourceName: 'people/622740',
         requestBody: expectedRequestBody,
         updatePersonFields: 'emailAddresses,names'
+      })
+    })
+  })
+
+  describe('getContact', () => {
+    it('should retrieve a contact on Google', async () => {
+      const result = await googleUtils.getContact('people/69042')
+      expect(result).toEqual({
+        resourceName: 'people/123456',
+        etag: '6f5f3948-375c-4b7f-8d6b-241ccb0fba8f'
+      })
+      expect(googleGetContactSpy).toHaveBeenCalledWith({
+        resourceName: 'people/69042',
+        personFields: ['names']
       })
     })
   })

--- a/src/__mocks__/googleapis.js
+++ b/src/__mocks__/googleapis.js
@@ -6,6 +6,14 @@ const createContact = jest.fn(() =>
 const updateContact = jest.fn(() =>
   Promise.resolve({ data: 'The contact was updated' })
 )
+const get = jest.fn(() =>
+  Promise.resolve({
+    data: {
+      resourceName: 'people/123456',
+      etag: '6f5f3948-375c-4b7f-8d6b-241ccb0fba8f'
+    }
+  })
+)
 
 class FakeOAuth2 {}
 
@@ -16,14 +24,16 @@ googleapis.google.auth = {
 googleapis.google.people = jest.fn(() => ({
   people: {
     createContact: createContact,
-    updateContact: updateContact
+    updateContact: updateContact,
+    get: get
   }
 }))
 
 googleapis.spies = {
   FakeOAuth2,
   createContact,
-  updateContact
+  updateContact,
+  get
 }
 
 module.exports = googleapis

--- a/src/__snapshots__/synchronizeContacts.spec.js.snap
+++ b/src/__snapshots__/synchronizeContacts.spec.js.snap
@@ -215,6 +215,48 @@ Array [
 ]
 `;
 
+exports[`synchronizeContacts function should synchronize contacts: destroyHowellTowne 1`] = `
+Array [
+  Object {
+    "_rev": "83152550-fe2b-42a4-a098-5d17c586d2bf",
+    "_type": "io.cozy.contacts",
+    "cozyMetadata": Object {
+      "createdAt": "2013-02-20T19:33:00.123Z",
+      "createdByApp": "Contacts",
+      "createdByAppVersion": "2.0.0",
+      "doctypeVersion": 2,
+      "sourceAccount": "45c49c15-4b00-48e8-8bfd-29f8177b89ff",
+      "sync": Object {
+        "45c49c15-4b00-48e8-8bfd-29f8177b89ff": Object {
+          "id": "people/1655899",
+        },
+      },
+      "updatedAt": "2017-01-12T12:12:01.222Z",
+      "updatedByApps": Array [
+        "konnector-google",
+      ],
+    },
+    "email": Array [],
+    "id": "howell-towne-hidden",
+    "metadata": Object {
+      "google": Object {
+        "metadata": Object {
+          "sources": Array [
+            Object {
+              "etag": "67465901-d316-4dcd-b866-977ff95b056e",
+            },
+          ],
+        },
+      },
+    },
+    "name": Object {
+      "familyName": "Towne",
+      "givenName": "Howell",
+    },
+  },
+]
+`;
+
 exports[`synchronizeContacts function should synchronize contacts: destroyJohannaMoenInCozy 1`] = `
 Array [
   Object {


### PR DESCRIPTION
Should fix etag error on some instances (first sync after migration), log debug infos if we have the etag problem but don't have 404 error on `getContact`

More details here: https://trello.com/c/RzUwd4MQ/1822-konnector-google-mauvais-etag