### PR TITLE
fix: Skip useless google updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ branches:
   - build-debug
 script:
 - yarn lint
+- yarn jest
 - yarn build
 # - yarn run check
 deploy:

--- a/src/__snapshots__/synchronizeContacts.spec.js.snap
+++ b/src/__snapshots__/synchronizeContacts.spec.js.snap
@@ -72,7 +72,10 @@ Array [
       },
       "updatedAt": "2019-02-12T12:18:00.222Z",
       "updatedByApps": Array [
-        "Contacts",
+        Object {
+          "date": "2019-02-12T12:18:00.222Z",
+          "slug": "Contacts",
+        },
       ],
     },
     "email": Array [
@@ -192,8 +195,14 @@ Array [
       },
       "updatedAt": "2018-11-12T18:18:00.222Z",
       "updatedByApps": Array [
-        "Contacts",
-        "konnector-google",
+        Object {
+          "date": "2018-11-12T18:18:00.222Z",
+          "slug": "Contacts",
+        },
+        Object {
+          "date": "2017-03-22T07:33:00.123Z",
+          "slug": "konnector-google",
+        },
       ],
     },
     "email": Array [],
@@ -233,7 +242,14 @@ Array [
       },
       "updatedAt": "2017-01-12T12:12:01.222Z",
       "updatedByApps": Array [
-        "konnector-google",
+        Object {
+          "date": "2017-01-12T12:12:01.222Z",
+          "slug": "Contacts",
+        },
+        Object {
+          "date": "2017-01-12T12:12:01.222Z",
+          "slug": "konnector-google",
+        },
       ],
     },
     "email": Array [],
@@ -276,8 +292,14 @@ Array [
       },
       "updatedAt": "2018-12-22T15:18:00.222Z",
       "updatedByApps": Array [
-        "Contacts",
-        "konnector-google",
+        Object {
+          "date": "2018-12-22T15:18:00.222Z",
+          "slug": "Contacts",
+        },
+        Object {
+          "date": "2018-04-22T17:33:00.123Z",
+          "slug": "konnector-google",
+        },
       ],
     },
     "id": "johanna-moen-deleted-on-google-conflict",
@@ -306,8 +328,14 @@ Array [
       "sourceAccount": "45c49c15-4b00-48e8-8bfd-29f8177b89ff",
       "updatedAt": "2018-12-22T15:18:00.222Z",
       "updatedByApps": Array [
-        "Contacts",
-        "konnector-google",
+        Object {
+          "date": "2018-12-22T15:18:00.222Z",
+          "slug": "Contacts",
+        },
+        Object {
+          "date": "2018-04-22T17:33:00.123Z",
+          "slug": "konnector-google",
+        },
       ],
     },
     "email": Array [],
@@ -360,7 +388,10 @@ Array [
       },
       "updatedAt": "2019-01-22T18:18:00.222Z",
       "updatedByApps": Array [
-        "Contacts",
+        Object {
+          "date": "2019-01-22T18:18:00.222Z",
+          "slug": "Contacts",
+        },
       ],
     },
     "email": Array [
@@ -512,7 +543,10 @@ Array [
       },
       "updatedAt": "2018-03-22T12:09:00.222Z",
       "updatedByApps": Array [
-        "Contacts",
+        Object {
+          "date": "2018-03-22T12:09:00.222Z",
+          "slug": "Contacts",
+        },
       ],
     },
     "email": Array [],
@@ -585,7 +619,10 @@ Array [
       },
       "updatedAt": "2018-11-11T09:09:00.222Z",
       "updatedByApps": Array [
-        "Contacts",
+        Object {
+          "date": "2018-11-11T09:09:00.222Z",
+          "slug": "Contacts",
+        },
       ],
     },
     "email": Array [],

--- a/src/__snapshots__/synchronizeContacts.spec.js.snap
+++ b/src/__snapshots__/synchronizeContacts.spec.js.snap
@@ -1,5 +1,47 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`synchronizeContacts function should skip existing contacts after a disconnect/reconnect: betsy-brady 1`] = `
+Array [
+  Object {
+    "addresses": Array [],
+    "biographies": Array [],
+    "birthdays": Array [],
+    "emailAddresses": Array [],
+    "names": Array [
+      Object {
+        "familyName": "Brady",
+        "givenName": "Betsy",
+      },
+    ],
+    "organizations": Array [],
+    "phoneNumbers": Array [],
+  },
+  "people/1753908",
+  "992765-d316-4dcd-b866-098982ab65",
+]
+`;
+
+exports[`synchronizeContacts function should skip existing contacts after a disconnect/reconnect: norma-allison 1`] = `
+Array [
+  Object {
+    "addresses": Array [],
+    "biographies": Array [],
+    "birthdays": Array [],
+    "emailAddresses": Array [],
+    "names": Array [
+      Object {
+        "familyName": "Allison",
+        "givenName": "Norma",
+      },
+    ],
+    "organizations": Array [],
+    "phoneNumbers": Array [],
+  },
+  "people/19804826",
+  "992765-d316-4dcd-b866-098982ab65",
+]
+`;
+
 exports[`synchronizeContacts function should synchronize contacts: adanMuellerInCozy 1`] = `
 Array [
   Object {
@@ -243,7 +285,7 @@ Array [
       "updatedAt": "2017-01-12T12:12:01.222Z",
       "updatedByApps": Array [
         Object {
-          "date": "2017-01-12T12:12:01.222Z",
+          "date": "2019-01-12T12:12:01.222Z",
           "slug": "Contacts",
         },
         Object {

--- a/src/synchronizeContacts.js
+++ b/src/synchronizeContacts.js
@@ -1,5 +1,6 @@
 const get = require('lodash/get')
 const uniqBy = require('lodash/uniqBy')
+const sortBy = require('lodash/sortBy')
 const pLimit = require('p-limit')
 const { log } = require('cozy-konnector-libs')
 
@@ -130,7 +131,11 @@ const determineActionOnCozy = (
 const determineActionOnGoogle = (cozyContact, contactAccountId) => {
   const syncInfo = get(cozyContact, `cozyMetadata.sync.${contactAccountId}`)
   const isTrashedOnCozy = cozyContact.trashed
-  const lastUpdatedBy = get(cozyContact, 'cozyMetadata.updatedByApps[0].slug')
+  const sortedLastUpdates = sortBy(
+    get(cozyContact, 'cozyMetadata.updatedByApps', []),
+    'date'
+  ).reverse()
+  const lastUpdatedBy = get(sortedLastUpdates, '[0].slug')
 
   if (isTrashedOnCozy) {
     return SHOULD_DELETE

--- a/src/synchronizeContacts.spec.js
+++ b/src/synchronizeContacts.spec.js
@@ -23,7 +23,12 @@ const cozyContacts = [
       createdByApp: 'Contacts',
       createdByAppVersion: '3.3.0',
       updatedAt: '2018-11-11T09:09:00.222Z',
-      updatedByApps: ['Contacts'],
+      updatedByApps: [
+        {
+          slug: 'Contacts',
+          date: '2018-11-11T09:09:00.222Z'
+        }
+      ],
       sourceAccount: undefined
     },
     relationships: {
@@ -44,7 +49,7 @@ const cozyContacts = [
       createdByApp: 'konnector-google',
       createdByAppVersion: '2.0.0',
       updatedAt: '2018-03-22T12:09:00.222Z',
-      updatedByApps: ['Contacts'],
+      updatedByApps: [{ slug: 'Contacts', date: '2018-03-22T12:09:00.222Z' }],
       sourceAccount: OTHER_SOURCE_ACCOUNT_ID,
       sync: {
         [OTHER_SOURCE_ACCOUNT_ID]: {
@@ -78,7 +83,7 @@ const cozyContacts = [
       createdByApp: 'Contacts',
       createdByAppVersion: '2.0.0',
       updatedAt: '2019-01-22T18:18:00.222Z',
-      updatedByApps: ['Contacts'],
+      updatedByApps: [{ slug: 'Contacts', date: '2019-01-22T18:18:00.222Z' }],
       sourceAccount: SOURCE_ACCOUNT_ID,
       sync: {
         [SOURCE_ACCOUNT_ID]: {
@@ -108,7 +113,7 @@ const cozyContacts = [
       createdByApp: 'Contacts',
       createdByAppVersion: '2.0.0',
       updatedAt: '2019-02-12T12:18:00.222Z',
-      updatedByApps: ['Contacts'],
+      updatedByApps: [{ slug: 'Contacts', date: '2019-02-12T12:18:00.222Z' }],
       sourceAccount: SOURCE_ACCOUNT_ID,
       sync: {
         [SOURCE_ACCOUNT_ID]: {
@@ -138,7 +143,10 @@ const cozyContacts = [
       createdByApp: 'Contacts',
       createdByAppVersion: '2.0.0',
       updatedAt: '2018-11-12T18:18:00.222Z',
-      updatedByApps: ['Contacts', 'konnector-google'],
+      updatedByApps: [
+        { slug: 'Contacts', date: '2018-11-12T18:18:00.222Z' },
+        { slug: 'konnector-google', date: '2017-03-22T07:33:00.123Z' }
+      ],
       sourceAccount: SOURCE_ACCOUNT_ID,
       sync: {
         [SOURCE_ACCOUNT_ID]: {
@@ -160,7 +168,10 @@ const cozyContacts = [
       createdByApp: 'Contacts',
       createdByAppVersion: '2.0.0',
       updatedAt: '2018-12-22T15:18:00.222Z',
-      updatedByApps: ['Contacts', 'konnector-google'],
+      updatedByApps: [
+        { slug: 'Contacts', date: '2018-12-22T15:18:00.222Z' },
+        { slug: 'konnector-google', date: '2018-04-22T17:33:00.123Z' }
+      ],
       sourceAccount: SOURCE_ACCOUNT_ID,
       sync: {
         [SOURCE_ACCOUNT_ID]: {
@@ -182,7 +193,10 @@ const cozyContacts = [
       createdByApp: 'Contacts',
       createdByAppVersion: '2.0.0',
       updatedAt: '2018-12-22T15:18:00.222Z',
-      updatedByApps: ['Contacts', 'konnector-google'],
+      updatedByApps: [
+        { slug: 'Contacts', date: '2018-12-22T15:18:00.222Z' },
+        { slug: 'konnector-google', date: '2018-04-22T17:33:00.123Z' }
+      ],
       sourceAccount: SOURCE_ACCOUNT_ID
     }
   },
@@ -199,7 +213,7 @@ const cozyContacts = [
       createdByApp: 'Contacts',
       createdByAppVersion: '2.0.0',
       updatedAt: '2019-01-22T18:18:00.222Z',
-      updatedByApps: ['Contacts'],
+      updatedByApps: [{ slug: 'Contacts', date: '2019-01-22T18:18:00.222Z' }],
       sourceAccount: SOURCE_ACCOUNT_ID,
       sync: {
         [SOURCE_ACCOUNT_ID]: {
@@ -232,7 +246,10 @@ const cozyContacts = [
       createdByApp: 'Contacts',
       createdByAppVersion: '2.0.0',
       updatedAt: '2017-01-12T12:12:01.222Z',
-      updatedByApps: ['konnector-google'],
+      updatedByApps: [
+        { slug: 'Contacts', date: '2019-01-12T12:12:01.222Z' },
+        { slug: 'konnector-google', date: '2017-01-12T12:12:01.222Z' }
+      ],
       sourceAccount: SOURCE_ACCOUNT_ID,
       sync: {
         [SOURCE_ACCOUNT_ID]: {
@@ -462,7 +479,8 @@ describe('synchronizeContacts function', () => {
       google: {
         created: 2,
         deleted: 1,
-        updated: 2
+        updated: 2,
+        skipped: 0
       }
     })
 
@@ -553,7 +571,8 @@ describe('synchronizeContacts function', () => {
       google: {
         created: 0,
         deleted: 0,
-        updated: 0
+        updated: 0,
+        skipped: 0
       }
     })
   })

--- a/src/synchronizeContacts.spec.js
+++ b/src/synchronizeContacts.spec.js
@@ -271,6 +271,148 @@ const cozyContacts = [
   }
 ]
 
+const cozyContactsAfterReboot = [
+  {
+    id: 'larry-finn-skipped',
+    _type: 'io.cozy.contacts',
+    _rev: '172bddd78-fe2b-42a4-a098-785bd546',
+    name: { givenName: 'Larry', familyName: 'Finn' },
+    email: [],
+    cozyMetadata: {
+      doctypeVersion: 2,
+      createdAt: '2013-02-20T19:33:00.123Z',
+      createdByApp: 'Contacts',
+      createdByAppVersion: '2.0.0',
+      updatedAt: '2017-01-12T12:12:01.222Z',
+      updatedByApps: [
+        { slug: 'konnector-google', date: '2017-01-12T12:12:01.222Z' }
+      ],
+      sourceAccount: SOURCE_ACCOUNT_ID,
+      sync: {
+        [SOURCE_ACCOUNT_ID]: {
+          id: 'people/1739820'
+        }
+      }
+    },
+    metadata: {
+      google: {
+        metadata: {
+          sources: [
+            {
+              etag: '992765-d316-4dcd-b866-098982ab65'
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    id: 'betsy-brady-updated',
+    _type: 'io.cozy.contacts',
+    _rev: '172bddd78-fe2b-42a4-a098-785bd546',
+    name: { givenName: 'Betsy', familyName: 'Brady' },
+    email: [],
+    cozyMetadata: {
+      doctypeVersion: 2,
+      createdAt: '2013-02-20T19:33:00.123Z',
+      createdByApp: 'Contacts',
+      createdByAppVersion: '2.0.0',
+      updatedAt: '2017-01-12T12:12:01.222Z',
+      updatedByApps: [
+        { slug: 'konnector-google', date: '2017-01-12T12:12:01.222Z' },
+        { slug: 'contacts', date: '2019-03-22T12:12:01.222Z' }
+      ],
+      sourceAccount: SOURCE_ACCOUNT_ID,
+      sync: {
+        [SOURCE_ACCOUNT_ID]: {
+          id: 'people/1753908'
+        }
+      }
+    },
+    metadata: {
+      google: {
+        metadata: {
+          sources: [
+            {
+              etag: '992765-d316-4dcd-b866-098982ab65'
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    id: 'gretchen-avery-updated-but-not-last',
+    _type: 'io.cozy.contacts',
+    _rev: '172bddd78-fe2b-42a4-a098-785bd546',
+    name: { givenName: 'Gretchen', familyName: 'Avery' },
+    email: [],
+    cozyMetadata: {
+      doctypeVersion: 2,
+      createdAt: '2013-02-20T19:33:00.123Z',
+      createdByApp: 'Contacts',
+      createdByAppVersion: '2.0.0',
+      updatedAt: '2017-01-12T12:12:01.222Z',
+      updatedByApps: [
+        { slug: 'konnector-google', date: '2018-01-12T12:12:01.222Z' },
+        { slug: 'contacts', date: '2017-01-12T12:12:01.222Z' }
+      ],
+      sourceAccount: SOURCE_ACCOUNT_ID,
+      sync: {
+        [SOURCE_ACCOUNT_ID]: {
+          id: 'people/661839'
+        }
+      }
+    },
+    metadata: {
+      google: {
+        metadata: {
+          sources: [
+            {
+              etag: '992765-d316-4dcd-b866-098982ab65'
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    id: 'norma-allison-updated-with-no-date',
+    _type: 'io.cozy.contacts',
+    _rev: '172bddd78-fe2b-42a4-a098-785bd546',
+    name: { givenName: 'Norma', familyName: 'Allison' },
+    email: [],
+    cozyMetadata: {
+      doctypeVersion: 2,
+      createdAt: '2013-02-20T19:33:00.123Z',
+      createdByApp: 'Contacts',
+      createdByAppVersion: '2.0.0',
+      updatedAt: '2017-01-12T12:12:01.222Z',
+      updatedByApps: [
+        'Contacts',
+        { slug: 'konnector-google', date: '2017-01-12T12:12:01.222Z' }
+      ],
+      sourceAccount: SOURCE_ACCOUNT_ID,
+      sync: {
+        [SOURCE_ACCOUNT_ID]: {
+          id: 'people/19804826'
+        }
+      }
+    },
+    metadata: {
+      google: {
+        metadata: {
+          sources: [
+            {
+              etag: '992765-d316-4dcd-b866-098982ab65'
+            }
+          ]
+        }
+      }
+    }
+  }
+]
+
 // this data comes from cozy.findContact
 const scarlettGutkowski = {
   id: 'scarlett-gutkowski-edited-on-google',
@@ -575,6 +717,38 @@ describe('synchronizeContacts function', () => {
         skipped: 0
       }
     })
+  })
+
+  it('should skip existing contacts after a disconnect/reconnect', async () => {
+    const googleContacts = []
+    const result = await synchronizeContacts(
+      SOURCE_ACCOUNT_ID,
+      cozyContactsAfterReboot,
+      googleContacts,
+      cozyUtils,
+      googleUtils
+    )
+    expect(result).toEqual({
+      cozy: {
+        created: 0,
+        deleted: 0,
+        updated: 0
+      },
+      google: {
+        created: 0,
+        deleted: 0,
+        updated: 2,
+        skipped: 2
+      }
+    })
+
+    expect(googleUtils.updateContact).toHaveBeenCalledTimes(2)
+    expect(googleUtils.updateContact.mock.calls[0]).toMatchSnapshot(
+      'betsy-brady'
+    )
+    expect(googleUtils.updateContact.mock.calls[1]).toMatchSnapshot(
+      'norma-allison'
+    )
   })
 
   it('should fail nicely on google error', async () => {


### PR DESCRIPTION
In case of a disconnect & reconnect, we were pushing updates to Google even though they weren't necessary. Avoiding them gives us more requests before we hit the quota.