### PR TITLE
fix: Don't use sync token when sync token is expired

### DIFF
--- a/src/__mocks__/googleapis.js
+++ b/src/__mocks__/googleapis.js
@@ -15,6 +15,15 @@ const get = jest.fn(() =>
   })
 )
 
+const listContacts = jest.fn(() =>
+  Promise.resolve({
+    data: {
+      connections: [],
+      nextSyncToken: 'new-sync-token'
+    }
+  })
+)
+
 class FakeOAuth2 {}
 
 googleapis.google.auth = {
@@ -25,7 +34,10 @@ googleapis.google.people = jest.fn(() => ({
   people: {
     createContact: createContact,
     updateContact: updateContact,
-    get: get
+    get: get,
+    connections: {
+      list: listContacts
+    }
   }
 }))
 
@@ -33,7 +45,8 @@ googleapis.spies = {
   FakeOAuth2,
   createContact,
   updateContact,
-  get
+  get,
+  listContacts
 }
 
 module.exports = googleapis


### PR DESCRIPTION
- if sync token is expired, ask for all contacts without sync token (we don't retrieve deleted contacts in this case)
- I had to rewrite `getConnectionsList` with `async`/`await` to be able to make my unit tests work